### PR TITLE
Fixes phonesim component demo

### DIFF
--- a/components/phonesim.html
+++ b/components/phonesim.html
@@ -20,7 +20,7 @@ title: Phone Simulator
 
 	<pre><code class="javascript">var tags = riot.mount('rg-phone-sim', {
   phonesim: {
-    url: 'http://riotjs.com/'
+    url: 'https://riotgear.js.org/'
   }
 })</code></pre>
 
@@ -31,7 +31,7 @@ title: Phone Simulator
 <script>
 	riot.mount('rg-phone-sim', {
 		phonesim: {
-			url: 'http://riotjs.com/'
+			url: 'https://riotgear.js.org/'
 		}
 	})
 </script>


### PR DESCRIPTION
The phonesim component on the website (https://riotgear.js.org/components/phonesim/) does not currently work for me, this fixes it.

I have changed the site from the Riot site to the RiotGear site, but I'm not sure this is a disimprovement. Let me know what you think :)