### PR TITLE
Makes the code display and use case for tags consistent with each other

### DIFF
--- a/components/tags.html
+++ b/components/tags.html
@@ -24,16 +24,16 @@ title: Tags
     placeholder: 'Choose a country',
     filter: 'text', // <-- this enables filtering on the 'text' property
     options: [{
-      text: 'England'
+      text: 'Canada'
     }, {
-      text: 'Scotland'
+      text: 'China'
     }, {
-      text: 'Ireland'
+      text: 'United States'
     }, {
-      text: 'Wales'
+      text: 'United Kingdom'
     }],
     tags: [{
-      text: 'United States'
+      text: 'Japan'
     }]
   }
 })


### PR DESCRIPTION
The tags usecase and javascript code display are out of sync (https://riotgear.js.org/components/tags/). I have fixed this here. Hope this is ok.